### PR TITLE
Add stub channel module and build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+MODULE=chan_dongle_ng.so
+SRC=src/chan_dongle_ng.c
+OBJ=$(SRC:.c=.o)
+
+CFLAGS+=-Iinclude $(ASTCFLAGS)
+LDFLAGS+=$(ASTLDFLAGS)
+
+all: $(MODULE)
+
+$(MODULE): $(OBJ)
+	$(CC) -shared -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f $(OBJ) $(MODULE)

--- a/include/chan_dongle_ng.h
+++ b/include/chan_dongle_ng.h
@@ -1,0 +1,7 @@
+#ifndef CHAN_DONGLE_NG_H
+#define CHAN_DONGLE_NG_H
+
+int load_module(void);
+int unload_module(void);
+
+#endif /* CHAN_DONGLE_NG_H */

--- a/src/chan_dongle_ng.c
+++ b/src/chan_dongle_ng.c
@@ -1,0 +1,17 @@
+#include "asterisk.h"
+#include "asterisk/module.h"
+#include "chan_dongle_ng.h"
+
+int load_module(void)
+{
+    ast_log(LOG_NOTICE, "chan_dongle_ng loaded\n");
+    return AST_MODULE_LOAD_SUCCESS;
+}
+
+int unload_module(void)
+{
+    ast_log(LOG_NOTICE, "chan_dongle_ng unloaded\n");
+    return 0;
+}
+
+AST_MODULE_INFO_STANDARD(ASTERISK_GPL_KEY, "Chan Dongle NG stub module");


### PR DESCRIPTION
## Summary
- add source and header for `chan_dongle_ng` module with minimal load/unload stubs
- add Makefile referencing Asterisk build flags for compiling `chan_dongle_ng.so`

## Testing
- `make` *(fails: `asterisk.h` not found)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_686a8edb8f6c8332a030be4d1086a43f