### PR TITLE
Add initial dongle_ng configuration and CLI skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ ASTCFLAGS=`asterisk -C | grep ^ASTCFLAGS= | cut -d= -f2`
 ASTLIBDIR=`asterisk -C | grep ^ASTLIBDIR= | cut -d= -f2`
 
 all:
-	gcc -fPIC -Wall -shared -o $(MODULE) $(SRC) $(ASTCFLAGS) -I/usr/include/asterisk
+	gcc -fPIC -Wall -shared -o $(MODULE) $(SRC) $(ASTCFLAGS) -I/usr/include/asterisk -I.
 	mv $(MODULE) $(ASTLIBDIR)/modules/

--- a/README.md
+++ b/README.md
@@ -37,17 +37,19 @@ Reload or restart Asterisk so the new module is loaded.
 
 ## Basic Configuration
 
-Edit or create `/etc/asterisk/dongle.conf` and define each connected modem. Example:
+Edit or create `/etc/asterisk/dongle_ng.conf` and define each connected modem. Example:
 
 ```ini
+
 [general]
-device=/dev/ttyUSB0
+autostart=yes
 
 [usb0]
 ; audio and data ports are detected automatically
 imei=123456789012345
 imsi=123456789012345
-``` 
+dev_path=/dev/ttyUSB0
+```
 
 Load the module by adding to `modules.conf`:
 
@@ -70,6 +72,20 @@ Incoming calls can be handled similarly:
 [dongle-in]
 exten => s,1,Answer()
  same => n,Dial(SIP/myphone)
+```
+
+## CLI Commands
+
+After the module is loaded you can inspect configured devices from the Asterisk CLI:
+
+```
+*CLI> dongle_ng show
+```
+
+To request a hard reset for a particular dongle use:
+
+```
+*CLI> dongle_ng reset <alias>
 ```
 
 ## Further Reading

--- a/chan_dongle_ng.c
+++ b/chan_dongle_ng.c
@@ -1,12 +1,68 @@
 #include "asterisk/module.h"
 #include "asterisk/logger.h"
+#include "asterisk/config.h"
+#include "asterisk/cli.h"
+#include "asterisk/strings.h"
+#include "asterisk/utils.h"
+#include "chan_dongle_ng.h"
+
+struct dongle_device_list g_device_list;
+
+static int load_config(void) {
+    struct ast_config *cfg;
+    const char *cat = NULL;
+    struct ast_variable *v;
+    struct ast_flags flags = {0};
+
+    AST_RWLIST_INIT(&g_device_list);
+
+    cfg = ast_config_load("dongle_ng.conf", flags);
+    if (!cfg) {
+        ast_log(LOG_ERROR, "Unable to load dongle_ng.conf\n");
+        return -1;
+    }
+
+    while ((cat = ast_category_browse(cfg, cat))) {
+        if (!strcmp(cat, "general"))
+            continue;
+
+        dongle_device_t *dev = ast_calloc(1, sizeof(*dev));
+        if (!dev) continue;
+        ast_copy_string(dev->alias, cat, sizeof(dev->alias));
+
+        for (v = ast_variable_browse(cfg, cat); v; v = v->next) {
+            if (!strcmp(v->name, "imei"))
+                ast_copy_string(dev->imei, v->value, sizeof(dev->imei));
+            else if (!strcmp(v->name, "sim_number"))
+                ast_copy_string(dev->sim_number, v->value, sizeof(dev->sim_number));
+            else if (!strcmp(v->name, "dev_path"))
+                ast_copy_string(dev->dev_path, v->value, sizeof(dev->dev_path));
+        }
+
+        AST_RWLIST_INSERT_TAIL(&g_device_list, dev, list);
+    }
+
+    ast_config_destroy(cfg);
+    return 0;
+}
 
 static int load_module(void) {
+    if (load_config())
+        return AST_MODULE_LOAD_FAILURE;
+    if (dongle_ng_cli_init())
+        ast_log(LOG_WARNING, "Failed to register CLI commands\n");
     ast_log(LOG_NOTICE, "chan_dongle_ng module loaded.\n");
     return AST_MODULE_LOAD_SUCCESS;
 }
 
 static int unload_module(void) {
+    dongle_device_t *dev;
+    AST_RWLIST_WRLOCK(&g_device_list);
+    while ((dev = AST_RWLIST_REMOVE_HEAD(&g_device_list, list))) {
+        ast_free(dev);
+    }
+    AST_RWLIST_UNLOCK(&g_device_list);
+    dongle_ng_cli_cleanup();
     ast_log(LOG_NOTICE, "chan_dongle_ng module unloaded.\n");
     return 0;
 }

--- a/chan_dongle_ng.h
+++ b/chan_dongle_ng.h
@@ -1,5 +1,6 @@
 #ifndef _CHAN_DONGLE_NG_H_
 #define _CHAN_DONGLE_NG_H_
+#include "asterisk/lock.h"
 
 typedef struct dongle_device {
     char imei[32];
@@ -14,6 +15,15 @@ typedef struct dongle_device {
     int is_registered;
     struct ast_channel *owner;
     pthread_t reader_thread;
+    AST_RWLIST_ENTRY(dongle_device) list;
 } dongle_device_t;
+
+AST_RWLIST_HEAD(dongle_device_list, dongle_device);
+
+extern struct dongle_device_list g_device_list;
+
+int dongle_ng_cli_init(void);
+void dongle_ng_cli_cleanup(void);
+
 
 #endif

--- a/chan_dongle_ng_cli.c
+++ b/chan_dongle_ng_cli.c
@@ -1,4 +1,6 @@
 #include "asterisk/cli.h"
+#include "asterisk/logger.h"
+#include "chan_dongle_ng.h"
 
 static char *cli_show_command(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a) {
     if (cmd == CLI_INIT) {
@@ -8,18 +10,39 @@ static char *cli_show_command(struct ast_cli_entry *e, int cmd, struct ast_cli_a
     } else if (cmd == CLI_GENERATE)
         return NULL;
 
-    ast_cli(a->fd, "dongle_ng CLI not implemented yet.\n");
+    dongle_device_t *dev;
+    AST_RWLIST_RDLOCK(&g_device_list);
+    AST_RWLIST_TRAVERSE(&g_device_list, dev, list) {
+        ast_cli(a->fd, "%-15s IMEI:%s SIM:%s\n", dev->alias, dev->imei, dev->sim_number);
+    }
+    AST_RWLIST_UNLOCK(&g_device_list);
+    return CLI_SUCCESS;
+}
+
+static char *cli_reset_command(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a) {
+    if (cmd == CLI_INIT) {
+        e->command = "dongle_ng reset";
+        e->usage = "Usage: dongle_ng reset <alias>\n       Reset a dongle device";
+        return NULL;
+    } else if (cmd == CLI_GENERATE)
+        return NULL;
+    if (a->argc != 3) {
+        return CLI_SHOWUSAGE;
+    }
+    const char *alias = a->argv[2];
+    ast_log(LOG_NOTICE, "Requested reset for %s\n", alias);
     return CLI_SUCCESS;
 }
 
 static struct ast_cli_entry cli_commands[] = {
     AST_CLI_DEFINE(cli_show_command, "Show dongle_ng devices"),
+    AST_CLI_DEFINE(cli_reset_command, "Reset dongle device"),
 };
 
-static int load_cli(void) {
+int dongle_ng_cli_init(void) {
     return ast_cli_register_multiple(cli_commands, ARRAY_LEN(cli_commands));
 }
 
-static int unload_cli(void) {
-    return ast_cli_unregister_multiple(cli_commands, ARRAY_LEN(cli_commands));
+void dongle_ng_cli_cleanup(void) {
+    ast_cli_unregister_multiple(cli_commands, ARRAY_LEN(cli_commands));
 }

--- a/dongle_ng.conf.example
+++ b/dongle_ng.conf.example
@@ -5,3 +5,4 @@ autostart=yes
 imei=123456789012345
 sim_number=01000000000
 alias=line-sales
+dev_path=/dev/ttyUSB0


### PR DESCRIPTION
## Summary
- parse `dongle_ng.conf` to load modem definitions
- expose a global list of dongles
- add CLI commands `dongle_ng show` and `dongle_ng reset`
- provide example configuration
- document CLI usage in README
- update Makefile include path

## Testing
- `make` *(fails: `asterisk` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa41c25c48332a63a1c29c7a1e208